### PR TITLE
Current implementation uploads file but doesn't trigger the build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ Then, some configuration for phonegap-build is needed:
 ### For repository-based applications (using a github repository)
 1. ```isRepository```: True to set the build method to "pull from repository"
 
+### Target platforms
+1. ```platforms```: array of the target platforms to build. For example:
+
+        platforms: ['ios', 'android']
+        
+Note: there is a bug in PhoneGap API that don't allow to trigger build until target platforms are specified.
+
 ### When unlocking keys
  1. ```keys```: A map of platform name [ios, android, ...] to parameters required to unlock the keys. For example:
 

--- a/tasks/phonegap-build.js
+++ b/tasks/phonegap-build.js
@@ -35,8 +35,25 @@ function start(taskRefs) {
       taskRefs.options.appId = appId;
       taskRefs.log.warn("APPID: " + appId);
     }
-    if (taskRefs.options.download) downloadApps(taskRefs, taskRefs.done);
-    else taskRefs.done();
+
+    var buildHandler = responseHandler("Build", taskRefs, function () {
+        if (taskRefs.options.download) downloadApps(taskRefs, taskRefs.done);
+        else taskRefs.done();
+    });
+
+    //There is a bug in PhoneGap Build API that doesn't allow to trigger build for all platforms
+    if (!taskRefs.options.platforms) {
+        taskRefs.log.warn("Target platform(s) is not specified.");
+    }
+
+    var config = {
+        multipart: true
+    };
+    var data = {
+        platforms: taskRefs.options.platforms || []
+    };
+    var postData = {data: JSON.stringify(data)};
+    taskRefs.needle.post('/api/v1/apps/'  + taskRefs.options.appId + '/build', postData, config, buildHandler);
   });
 
   taskRefs.needle = wrapNeedle("https://build.phonegap.com", taskRefs.options);


### PR DESCRIPTION
To trigger phonegap build additional request has to be sent to 
POST https://build.phonegap.com/api/v1/apps/:id/build

Such request should trigger a build for all registered platforms but there is a problem in API that doesn't allow to trigger the build until target platforms are specified. 
http://community.phonegap.com/nitobi/topics/unable-to-trigger-build-for-all-platforms-using-api?rfm=1
