### PR TITLE
Enable streaming around phonegap-build task.

### DIFF
--- a/tasks/phonegap-build.js
+++ b/tasks/phonegap-build.js
@@ -202,8 +202,8 @@ module.exports = function (options) {
 
         zip.append(file.contents, { name: file.relative });
         cb();
-    }, function () {
-      var   done = function () { self.emit('pg-sent'); taskRefs.log.ok('Application sent'); },
+    }, function (cb) {
+      var   done = function () { self.emit('pg-sent'); taskRefs.log.ok('Application sent'); cb(); },
             self = this,
             taskRefs = {
                 log: {


### PR DESCRIPTION
Add the callback function into flush function of through.job.
Call it into done function.
