### PR TITLE
Use timeout setting also for zip uploads

### DIFF
--- a/tasks/phonegap-build.js
+++ b/tasks/phonegap-build.js
@@ -123,6 +123,7 @@ function uploadZip(taskRefs, callback) {
             content_type: 'application/octet-stream'
         }
         config.multipart = true;
+        config.timeout = taskRefs.options.timeout;
     }
 
     taskRefs.log.ok("Starting upload");


### PR DESCRIPTION
The `timeout` option was not used in the upload request (in `uploadZip()`), but can be convenient for slower connections and larger files.
