### PR TITLE
fix infinite check state loop

### DIFF
--- a/tasks/phonegap-build.js
+++ b/tasks/phonegap-build.js
@@ -37,7 +37,7 @@ function start(taskRefs) {
     }
 
     var buildHandler = responseHandler("Build", taskRefs, function () {
-        if (taskRefs.options.download) downloadApps(taskRefs, taskRefs.done);
+        if (taskRefs.options.download && Object.keys(taskRefs.options.download).length) downloadApps(taskRefs, taskRefs.done);
         else taskRefs.done();
     });
 


### PR DESCRIPTION
when download option is an empty object options.download = { }; 
the task keep checking for build state forever.
